### PR TITLE
adds .doc mime type for types which can be converted to pdf

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -80,8 +80,11 @@ const (
 	// PdfMimeType is the mime type of a .pdf file.
 	PdfMimeType = "application/pdf"
 
-	// DocMimeType is the mime type of a .doc/x file.
-	DocMimeType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	// DocMimeType is the mime type of a .doc file.
+	DocMimeType = "application/msword"
+
+ 	// DocxMimeType is the mime type of a .docx file.
+	DocxMimeType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 
 	// XlsMimeType is the mime type of a .xls file.
 	XlsMimeType = "application/vnd.ms-excel"
@@ -109,6 +112,7 @@ var (
 	// TypesConvertableToPdf is a slice of the names of the mime types that can be converted to PDF and previewed.
 	TypesConvertableToPdf = []string{
 		DocMimeType,
+		DocxMimeType,
 		XlsMimeType,
 		XlsxMimeType,
 		PptMimeType,


### PR DESCRIPTION
A fix from [Omri's commit](https://github.com/meateam/api-gateway/commit/85b9f22f3f2ba28f51fc56f0067733f2b33e4b0b#diff-3a6a81f23576f46a4c6e6ab834f04b16).
Signed-off-by: Yonatan <yonatald@gmail.com>