### PR TITLE
refactor: get rid of the service auth type (deprecated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - FEAT([162](https://github.com/meateam/api-gateway/pull/162)): add auth startegy for docs
 
-## [Unreleased]
-
 [unreleased]: https://github.com/meateam/api-gateway/compare/master...develop
 [v2.1.0]: https://github.com/meateam/api-gateway/compare/v2.0.0...v2.1.0
 [v2.0.0]: https://github.com/meateam/api-gateway/compare/v1.3...v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- FEAT([143](https://github.com/meateam/api-gateway/pull/143)): add oauth, scopes enforcing, appID, and change `AuthTypeHeader` values
+- Files will now have an `appID` field with the value of the client ID which created the file.
+
+- External apps (which does not include `Dropbox` and `Docs`) can now preform actions on behalf of users by authenticating with `authcode` grant-type (oauth):
+  - The actions will be granted by scopes and may include: `upload`, `download`, `get-metadata`, `share`, `delete`.
+  - New files will be created with the new `appID` field of the external app.
+  - All of the actions, except `upload` will only be permitted on fiels with corresponding `appID` (the ID of the external app).
+  - The new created files will not be visible in the main client's pages, but only by search. 
+ 
+
+### Changed
+
+- Authentication for Dropbox will **only** work with the `Auth-Type` header value of `Dropbox` instead of `Service`.
+
 
 ## [v2.0.0] - 2020-10-28
 

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -32,9 +32,6 @@ const (
 	// AuthTypeHeader is the key of the service-host header
 	AuthTypeHeader = "Auth-Type"
 
-	// DEPRECATED: ServiceAuthTypeValue is the value of service for AuthTypeHeader key
-	ServiceAuthTypeValue = "Service"
-
 	// DropboxAuthTypeValue is the value of the AuthTypeHeader key for the Dropbox services
 	DropboxAuthTypeValue = "Dropbox"
 
@@ -114,9 +111,6 @@ func (m *Middleware) AuthorizationScopeMiddleware(requiredScope string) gin.Hand
 		var err error
 
 		switch authType {
-              // DEPRECATED: this case should be deleted in the next version 
-		case ServiceAuthTypeValue:
-			err = m.dropboxAuthorization(ctx, requiredScope)
 		case DropboxAuthTypeValue:
 			err = m.dropboxAuthorization(ctx, requiredScope)
 		case ServiceAuthCodeTypeValue:
@@ -329,13 +323,6 @@ func (m *Middleware) ValidateRequiredScope(ctx *gin.Context, requiredScope strin
 	if appID == DriveAppID {
 		return true
 	}
-
-	// temporary dropbox
-	authType := ctx.Value(ContextAuthType)
-	if authType == DropboxAuthTypeValue {
-		return true
-	}
-	// temporary
 
 	contextScopes := ctx.Value(ContextScopesKey)
 	var scopes []string


### PR DESCRIPTION
Signed-off-by: YonatanTal <yonatald@gmail.com>