### PR TITLE
Hotfix/dropbox auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.1] - 2020-11-11
+
+### Fixed
+
+- BUG([190](https://github.com/meateam/api-gateway/pull/190)): Dropbox Auth-Type fix.
+
 ## [v2.1.0] - 2020-11-1
 
 ### Added
@@ -32,5 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FEAT([162](https://github.com/meateam/api-gateway/pull/162)): add auth startegy for docs
 
 [unreleased]: https://github.com/meateam/api-gateway/compare/master...develop
+[v2.1.1]: https://github.com/meateam/api-gateway/compare/v2.1.0...v2.1.1
 [v2.1.0]: https://github.com/meateam/api-gateway/compare/v2.0.0...v2.1.0
 [v2.0.0]: https://github.com/meateam/api-gateway/compare/v1.3...v2.0.0

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -84,8 +84,7 @@ func (r *Router) Middleware(secrets Secrets, authURL string) gin.HandlerFunc {
 
 		serviceName := c.GetHeader(AuthTypeHeader)
 
-		// TODO: in the future, should be only ServiceAuthCodeTypeValue
-		if serviceName != ServiceAuthTypeValue && serviceName != ServiceAuthCodeTypeValue {
+		if serviceName != oauth.DropboxAuthTypeValue && serviceName != ServiceAuthCodeTypeValue {
 			// If not an external service, then it is a user.
 			secret := secrets.Drive
 


### PR DESCRIPTION
Bug cause: Part of the condition for running the user authentication route was set to `Service` instead of `Dropbox`.

Bug solution: replace the Auth-Type `Service` to `Dropbox` in the condition.

-- in collaboration  with @nogahaskal  --